### PR TITLE
Added animation scaling, removed boost dependency (switch to c++11),  and fixed animation speed.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/*
+CMakeLists.txt.user

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@
 # -----------------------------------------------------------------------------
 #*/
 cmake_minimum_required(VERSION 2.8)
-
+set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/CMakeModules;${CMAKE_MODULE_PATH}")
 
 project(ogreassimp)

--- a/src/AssimpLoader.cpp
+++ b/src/AssimpLoader.cpp
@@ -62,7 +62,7 @@ THE SOFTWARE.
 #include "OgreLodStrategyManager.h"
 #include "OgreDistanceLodStrategy.h"
 #include "Ogre.h"
-#include <boost/tuple/tuple.hpp>
+#include <tuple>
 //#include "OgreXMLSkeletonSerializer.h"
 
 Ogre::String toString(const aiColor4D& colour)
@@ -340,7 +340,7 @@ bool AssimpLoader::convert(const AssOptions options, Ogre::MeshPtr *meshPtr,  Og
 }
 
 
-typedef boost::tuple< aiVectorKey*, aiQuatKey*, aiVectorKey* > KeyframeData;
+typedef std::tuple< aiVectorKey*, aiQuatKey*, aiVectorKey* > KeyframeData;
 typedef std::map< Ogre::Real, KeyframeData > KeyframesMap;
 
 template <int v>
@@ -360,7 +360,7 @@ template< typename T > void GetInterpolationIterators(KeyframesMap& keyframes,
     front++;
     for(front; front != keyframes.rend(); front++)
     {
-        if(boost::get< T::value >(front->second) != NULL)
+        if(std::get< T::value >(front->second) != NULL)
         {
             break;
         }
@@ -370,7 +370,7 @@ template< typename T > void GetInterpolationIterators(KeyframesMap& keyframes,
     back++;
     for(back; back != keyframes.end(); back++)
     {
-        if(boost::get< T::value >(back->second) != NULL)
+        if(std::get< T::value >(back->second) != NULL)
         {
             break;
         }
@@ -379,7 +379,7 @@ template< typename T > void GetInterpolationIterators(KeyframesMap& keyframes,
 
 aiVector3D getTranslate(aiNodeAnim* node_anim, KeyframesMap& keyframes, KeyframesMap::iterator it, Ogre::Real ticksPerSecond)
 {
-    aiVectorKey* translateKey = boost::get<0>(it->second);
+    aiVectorKey* translateKey = std::get<0>(it->second);
     aiVector3D vect;
     if(translateKey)
     {
@@ -399,10 +399,10 @@ aiVector3D getTranslate(aiNodeAnim* node_anim, KeyframesMap& keyframes, Keyframe
         aiVectorKey* backKey = NULL;
 
         if(front != rend)
-            frontKey = boost::get<0>(front->second);
+            frontKey = std::get<0>(front->second);
 
         if(back != end)
-            backKey = boost::get<0>(back->second);
+            backKey = std::get<0>(back->second);
 
         // got 2 keys can interpolate
         if(frontKey && backKey)
@@ -427,7 +427,7 @@ aiVector3D getTranslate(aiNodeAnim* node_anim, KeyframesMap& keyframes, Keyframe
 
 aiQuaternion getRotate(aiNodeAnim* node_anim, KeyframesMap& keyframes, KeyframesMap::iterator it, Ogre::Real ticksPerSecond)
 {
-    aiQuatKey* rotationKey = boost::get<1>(it->second);
+    aiQuatKey* rotationKey = std::get<1>(it->second);
     aiQuaternion rot;
     if(rotationKey)
     {
@@ -446,10 +446,10 @@ aiQuaternion getRotate(aiNodeAnim* node_anim, KeyframesMap& keyframes, Keyframes
         aiQuatKey* backKey = NULL;
 
         if(front != rend)
-            frontKey = boost::get<1>(front->second);
+            frontKey = std::get<1>(front->second);
 
         if(back != end)
-            backKey = boost::get<1>(back->second);
+            backKey = std::get<1>(back->second);
 
         // got 2 keys can interpolate
         if(frontKey && backKey)
@@ -594,7 +594,7 @@ void AssimpLoader::parseAnimation (const aiScene* mScene, int index, aiAnimation
                 KeyframesMap::iterator it = keyframes.find((Ogre::Real)node_anim->mRotationKeys[i].mTime / mTicksPerSecond);
                 if(it != keyframes.end())
                 {
-                    boost::get<1>(it->second) = &(node_anim->mRotationKeys[i]);
+                    std::get<1>(it->second) = &(node_anim->mRotationKeys[i]);
                 }
                 else
                 {
@@ -607,7 +607,7 @@ void AssimpLoader::parseAnimation (const aiScene* mScene, int index, aiAnimation
                 KeyframesMap::iterator it = keyframes.find((Ogre::Real)node_anim->mScalingKeys[i].mTime / mTicksPerSecond);
                 if(it != keyframes.end())
                 {
-                    boost::get<2>(it->second) = &(node_anim->mScalingKeys[i]);
+                    std::get<2>(it->second) = &(node_anim->mScalingKeys[i]);
                 }
                 else
                 {
@@ -1244,7 +1244,7 @@ bool AssimpLoader::createSubMesh(const Ogre::String& name, int index, const aiNo
     size_t offset = 0;
     offset += declaration->addElement(source,offset,Ogre::VET_FLOAT3,Ogre::VES_POSITION).getSize();
 
-    //mLog->logMessage((boost::format(" %d vertices ") % m->mNumVertices).str());
+    //mLog->logMessage((std::format(" %d vertices ") % m->mNumVertices).str());
     if(!mQuietMode)
     {
         Ogre::LogManager::getSingleton().logMessage(Ogre::StringConverter::toString(mesh->mNumVertices) + " vertices");
@@ -1255,7 +1255,7 @@ bool AssimpLoader::createSubMesh(const Ogre::String& name, int index, const aiNo
         {
             Ogre::LogManager::getSingleton().logMessage(Ogre::StringConverter::toString(mesh->mNumVertices) + " normals");
         }
-        //mLog->logMessage((boost::format(" %d normals ") % m->mNumVertices).str() );
+        //mLog->logMessage((std::format(" %d normals ") % m->mNumVertices).str() );
         offset += declaration->addElement(source,offset,Ogre::VET_FLOAT3,Ogre::VES_NORMAL).getSize();
     }
 
@@ -1265,7 +1265,7 @@ bool AssimpLoader::createSubMesh(const Ogre::String& name, int index, const aiNo
         {
             Ogre::LogManager::getSingleton().logMessage(Ogre::StringConverter::toString(mesh->mNumVertices) + " uvs");
         }
-        //mLog->logMessage((boost::format(" %d uvs ") % m->mNumVertices).str() );
+        //mLog->logMessage((std::format(" %d uvs ") % m->mNumVertices).str() );
         offset += declaration->addElement(source,offset,Ogre::VET_FLOAT2,Ogre::VES_TEXTURE_COORDINATES).getSize();
     }
 
@@ -1273,7 +1273,7 @@ bool AssimpLoader::createSubMesh(const Ogre::String& name, int index, const aiNo
     if (col)
     {
         Ogre::LogManager::getSingleton().logMessage(Ogre::StringConverter::toString(mesh->mNumVertices) + " colours");
-        //mLog->logMessage((boost::format(" %d colours ") % m->mNumVertices).str() );
+        //mLog->logMessage((std::format(" %d colours ") % m->mNumVertices).str() );
         offset += declaration->addElement(source,offset,Ogre::VET_FLOAT3,Ogre::VES_DIFFUSE).getSize();
     }
     */

--- a/tool/main.cpp
+++ b/tool/main.cpp
@@ -103,7 +103,7 @@ AssimpLoader::AssOptions parseArgs(int numArgs, char **args)
     unOpt["-shader"] = false;
     binOpt["-log"] = "ass.log";
     binOpt["-aniName"] = "";
-    binOpt["-aniSpeedMod"] = 1.0f;
+    binOpt["-aniSpeedMod"] = "1.0";
     binOpt["-l"] = "";
     binOpt["-v"] = "";
     binOpt["-s"] = "Distance";


### PR DESCRIPTION
## Added

* Scaling in animation keyframes

## Removed

* Dependency on boost. `std::get` and `std::tuple` are all in C++11. Boost seems like a huge dependency to include just for tuple functionality. If people still need to be able to build without c++11, then it might make sense to just create a struct to hold the tuple types like so

```cpp
struct KeyFrameData {
    aiVectorKey* translation;
    aiQuatKey* rotation;
    aiVectorKey* scale;
}
```

## Fixed

* animation speed was set to zero because 1.0f -> string conversion, converted to zero, which made the animation length infinity. It was an easy fix to just explicitly set the initial value to "1.0". fixes #2 