### PR TITLE
memory bug (issue#10) fixed. compile bug (no issue) fixed

### DIFF
--- a/src/AssimpLoader.cpp
+++ b/src/AssimpLoader.cpp
@@ -1392,6 +1392,7 @@ bool AssimpLoader::createSubMesh(const Ogre::String& name, int index, const aiNo
 
             for (size_t i=0; i < mesh->mNumFaces;++i)
             {
+                    // this is a quick hack to filter lines, which are currently not supported
                     if(faces->mNumIndices != 3) {
                             *indexData++ = 0;
                             *indexData++ = 0;
@@ -1415,6 +1416,7 @@ bool AssimpLoader::createSubMesh(const Ogre::String& name, int index, const aiNo
 
             for (size_t i=0; i < mesh->mNumFaces;++i)
             {
+                    // this is a quick hack to filter lines, which are currently not supported
                     if(faces->mNumIndices != 3) {
                             *indexData++ = 0;
                             *indexData++ = 0;

--- a/src/AssimpLoader.cpp
+++ b/src/AssimpLoader.cpp
@@ -316,6 +316,8 @@ bool AssimpLoader::convert(const AssOptions options, Ogre::MeshPtr *meshPtr,  Og
 		}
     }
 
+    for(auto mesh: mMeshes)
+        mesh->load();
 
     // clean up
     mMeshes.clear();
@@ -1390,6 +1392,13 @@ bool AssimpLoader::createSubMesh(const Ogre::String& name, int index, const aiNo
 
             for (size_t i=0; i < mesh->mNumFaces;++i)
             {
+                    if(faces->mNumIndices != 3) {
+                            *indexData++ = 0;
+                            *indexData++ = 0;
+                            *indexData++ = 0;
+                            faces++;
+                            continue;
+                    }
                     *indexData++ = faces->mIndices[0];
                     *indexData++ = faces->mIndices[1];
                     *indexData++ = faces->mIndices[2];
@@ -1406,6 +1415,13 @@ bool AssimpLoader::createSubMesh(const Ogre::String& name, int index, const aiNo
 
             for (size_t i=0; i < mesh->mNumFaces;++i)
             {
+                    if(faces->mNumIndices != 3) {
+                            *indexData++ = 0;
+                            *indexData++ = 0;
+                            *indexData++ = 0;
+                            faces++;
+                            continue;
+                    }
                     *indexData++ = faces->mIndices[0];
                     *indexData++ = faces->mIndices[1];
                     *indexData++ = faces->mIndices[2];

--- a/tool/main.cpp
+++ b/tool/main.cpp
@@ -243,7 +243,7 @@ Ogre::FileSystemArchiveFactory* mfsarchf = 0;
 class DefaultTexture : public Ogre::Texture
 {
     void loadImpl() {}
-    Ogre::HardwarePixelBufferSharedPtr getBuffer(size_t, size_t)
+    const Ogre::HardwarePixelBufferSharedPtr& getBuffer(size_t, size_t)
     {
         return Ogre::HardwarePixelBufferSharedPtr();
     }

--- a/tool/main.cpp
+++ b/tool/main.cpp
@@ -240,43 +240,7 @@ Ogre::ScriptCompilerManager* scmgr = 0;
 Ogre::ArchiveManager* archmgr = 0;
 Ogre::FileSystemArchiveFactory* mfsarchf = 0;
 
-class DefaultTexture : public Ogre::Texture
-{
-    void loadImpl() {}
-    const Ogre::HardwarePixelBufferSharedPtr& getBuffer(size_t, size_t)
-    {
-        return Ogre::HardwarePixelBufferSharedPtr();
-    }
-    void createInternalResourcesImpl() {}
-    void freeInternalResourcesImpl() {}
-public:
-    DefaultTexture(Ogre::ResourceManager* creator, const Ogre::String& name, Ogre::ResourceHandle handle,
-        const Ogre::String& group) : Ogre::Texture(creator, name, handle, group) {}
-};
-
-class DefaultTextureManager : public Ogre::TextureManager
-{
-public:
-  bool isHardwareFilteringSupported(Ogre::TextureType, Ogre::PixelFormat, int,
-                                    bool) {
-    return false;
-  }
-
-  Ogre::PixelFormat getNativeFormat(Ogre::TextureType, Ogre::PixelFormat, int)
-  {
-      return Ogre::PF_UNKNOWN;
-  }
-
-  Ogre::Resource* createImpl(const Ogre::String& name,
-                             Ogre::ResourceHandle handle,
-                             const Ogre::String& group, bool,
-                             Ogre::ManualResourceLoader*,
-                             const Ogre::NameValuePairList*) {
-    return new DefaultTexture(this, name, handle, group);
-  }
-};
-
-DefaultTextureManager* texMgr = 0;
+Ogre::DefaultTextureManager* texMgr = 0;
 
 int main(int numargs, char** args)
 {
@@ -319,7 +283,7 @@ int main(int numargs, char** args)
         mfsarchf = new Ogre::FileSystemArchiveFactory();
         Ogre::ArchiveManager::getSingleton().addArchiveFactory( mfsarchf );
 
-        texMgr = new DefaultTextureManager();
+        texMgr = new Ogre::DefaultTextureManager();
 
         if(opts.quietMode)
             opts.params |= AssimpLoader::LP_QUIET_MODE;


### PR DESCRIPTION
Please check github issue #10. The index issue solution is very hacky. I am not knowledgeable enough on this topic to make a proper fix. But this solution is still much better than wrong memory access.

missing const and & symbol resulted in a compile failure. Not sure how it worked before. Is it due to the Ogre version that I am using?

I tested this fix on Ogre 1.12.1 and Ubuntu 16.04. 